### PR TITLE
Remove package from atmospherejs.com

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name: 'LyuGGang:materialize-meteor',
+  name: 'XXX:XXX',
   summary: 'A modern responsive front-end framework based on Material Design',
   version: '1.94.1',
   git: 'https://github.com/LyuGGang/materialize-meteor.git'


### PR DESCRIPTION
There's now an official package for materialize: see [materialize:materialize](https://atmospherejs.com/materialize/materialize).

Since the authors of Materialize accepted the [Meteor Integration PR](https://github.com/Dogfalo/materialize/pull/640) and correctly registered the package on [autopublish.meteor.com](http://autopublish.meteor.com/) we'll have same day updates at every new release of materialize.

Please kindly unmigrate this package on atmosphere running the following from your terminal:

```
meteor admin set-unmigrated lyuggang:materialize-meteor
```

Thank you,
Luca
